### PR TITLE
Group Python tooling and GitHub Actions updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>MihaiBojin/renovate"]
+  "extends": [
+    "github>MihaiBojin/renovate",
+    "github>MihaiBojin/renovate:group-github-actions",
+    "github>MihaiBojin/renovate:group-python-tooling"
+  ]
 }


### PR DESCRIPTION
Adds two grouping profiles from [MihaiBojin/renovate](https://github.com/MihaiBojin/renovate).

This repo currently gets one PR per dev tool (`build`, `pre-commit`, `pytest`, `twine`, `wheel`, `wheel-inspect`) and one per action. They are the updates with the smallest blast radius here, and they mostly release in the same window, so nearly all the review cost is PR count rather than risk.

| Profile | Scope |
| --- | --- |
| `group-github-actions` | non-major action updates, one PR |
| `group-python-tooling` | `pypi` datasource only, non-major, one PR |

Majors still arrive individually, and the `pypi` scoping means bare names like `build` and `wheel` cannot collide with same-named packages in other ecosystems.

Already running on `waf-downloader`.