### PR TITLE
Enable the pre-commit manager

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
   "extends": [
     "github>MihaiBojin/renovate",
     "github>MihaiBojin/renovate:group-github-actions",
-    "github>MihaiBojin/renovate:group-python-tooling"
+    "github>MihaiBojin/renovate:group-python-tooling",
+    "github>MihaiBojin/renovate:pre-commit"
   ]
 }


### PR DESCRIPTION
Adds [`github>MihaiBojin/renovate:pre-commit`](https://github.com/MihaiBojin/renovate/blob/main/pre-commit.json).

Renovate ships its `pre-commit` manager **disabled by default**, so `.pre-commit-config.yaml` has been invisible to it while every other dependency here stayed current. The hook revisions show the drift:

> pre-commit-hooks v3.4.0 (Dec 2020) vs v6.0.0, ruff-pre-commit v0.4.4 vs v0.16.0, mirrors-mypy v1.10.0 vs v2.3.0, keep-sorted v0.4.0 vs v0.9.1

The profile turns the manager on and groups hook updates into one PR, since enabling it on a repo with five hooks would otherwise open five PRs at once for the lowest-risk updates there are.

Expect one grouped "pre-commit hooks" PR after this merges. Review it rather than automerging — a multi-major ruff jump can change formatting, so the first one may need real attention.