### PR TITLE
Publish to PyPI with OIDC instead of API tokens

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -40,6 +40,12 @@ jobs:
   publish:
     needs: lint-test
     runs-on: ubuntu-latest
+    permissions:
+      # Mints the OIDC token that PyPI exchanges for a short-lived upload
+      # token. Naming any permission drops the defaults, so 'contents: read'
+      # has to be restated for the checkout.
+      id-token: write
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -58,17 +64,17 @@ jobs:
         working-directory: python
         run: uv build
 
+      # No tokens: PyPI and test.PyPI each exchange this workflow's OIDC
+      # identity for a short-lived upload token. 'always' rather than the
+      # default 'automatic' so a missing or misconfigured trusted publisher
+      # fails loudly instead of falling back to looking for credentials.
       - name: Publish package to test repository
-        env:
-          UV_PUBLISH_TOKEN: ${{ secrets.TESTPYPI_PASSWORD }}
         working-directory: python
-        run: uv publish --index testpypi
+        run: uv publish --index testpypi --trusted-publishing always
 
       - name: Publish package
-        env:
-          UV_PUBLISH_TOKEN: ${{ secrets.PYPI_PASSWORD }}
         working-directory: python
-        run: uv publish
+        run: uv publish --trusted-publishing always
 
       - name: Waiting 30 seconds for the PyPI indexes to be updated
         run: sleep 30

--- a/python/README.md
+++ b/python/README.md
@@ -133,9 +133,15 @@ git push origin v0.1.x
 
 A [GitHub Action](https://github.com/jazzy-fish/jazzy-fish/actions) will run, build the library and publish it to the PyPI repositories.
 
+The workflow authenticates with [Trusted Publishing](https://docs.pypi.org/trusted-publishers/), so it
+holds no API tokens. PyPI and test.PyPI each exchange the workflow's OIDC identity for a short-lived
+upload token, which requires `id-token: write` on the publishing job and a trusted publisher registered
+on **both** indexes, pointing at `python-publish.yml` in this repository.
+
 #### Manual
 
-These steps can also be performed locally. For these commands to work, you will need to export two environment variables:
+These steps can also be performed locally. Trusted Publishing only works from CI, so publishing by hand
+still needs tokens:
 
 ```shell
 export TESTPYPI_PASSWORD=... # token for https://test.pypi.org/legacy/


### PR DESCRIPTION
Replaces the long-lived PyPI API tokens in the publish workflow with [Trusted Publishing](https://docs.pypi.org/trusted-publishers/). PyPI and test.PyPI each exchange the workflow's own OIDC identity for an upload token scoped to a single release, so nothing durable is stored in repository secrets — there is no token to leak or rotate.

This was originally pushed to #78, but that PR was squash-merged from the state before the commit landed, so the change never reached `main`. Cherry-picked here onto the merged uv migration; it applied cleanly.

## Changes

```yaml
permissions:
  id-token: write
  contents: read
...
- run: uv publish --index testpypi --trusted-publishing always
- run: uv publish --trusted-publishing always
```

- `id-token: write` mints the OIDC token. Naming any permission drops GitHub's defaults, so `contents: read` is restated for the checkout and `detect-and-set-tag-version.bash`
- `--trusted-publishing always` rather than the default `automatic`. Under `automatic`, uv silently falls back to hunting for credentials when OIDC is unavailable; with the tokens now gone that would surface as a confusing auth error. `always` fails loudly and points at the real cause
- The `UV_PUBLISH_TOKEN` env blocks are gone; no `secrets.` reference remains in the file

Local publishing (`make publish` / `make publish-test`) still uses tokens, since Trusted Publishing only works from CI. Those targets are unchanged and `python/README.md` now says so explicitly.

## ⚠️ Required before the next tag

A trusted publisher must be registered on **both** indexes, or the release fails at the publish step:

| Field | Value |
|---|---|
| Owner | `MihaiBojin` |
| Repository | `jazzy-fish` |
| Workflow | `python-publish.yml` |
| Environment | *(leave blank)* |

Register at [pypi.org](https://pypi.org/manage/account/publishing/) **and** [test.pypi.org](https://test.pypi.org/manage/account/publishing/) — separate configurations. Afterwards the `TESTPYPI_PASSWORD` and `PYPI_PASSWORD` secrets can be deleted.

## Verification

`make lint` passes and the workflow YAML parses with the expected permissions. Note that CI cannot exercise this: the publish job only runs on a `v0.*` tag, so the checks here cover lint and tests only. The first real proof is the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)