### PR TITLE
Point repository URLs at the current owner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Jazzy Fish - Sufficiently-large, unique, human-friendly identifiers
 
-![Build Status](https://github.com/jazzy-fish/jazzy-fish/actions/workflows/python-tests.yml/badge.svg)
+![Build Status](https://github.com/MihaiBojin/jazzy-fish/actions/workflows/python-tests.yml/badge.svg)
 [![PyPI version](https://badge.fury.io/py/jazzy-fish.svg)](https://badge.fury.io/py/jazzy-fish)
 [![Python Versions](https://img.shields.io/pypi/pyversions/jazzy-fish.svg)](https://pypi.org/project/jazzy-fish/)
-[![License](https://img.shields.io/github/license/jazzy-fish/jazzy-fish.svg)](LICENSE)
+[![License](https://img.shields.io/github/license/MihaiBojin/jazzy-fish.svg)](LICENSE)
 
 Jazzy Fish is a library that helps you generate a sufficient number of identifiers, with a human-friendly kick.
 
@@ -33,7 +33,7 @@ Install it via:
 pip install jazzy-fish
 
 # or alternatively, directly from git
-pip install "git+https://github.com/jazzy-fish/jazzy-fish@main#subdirectory=python"
+pip install "git+https://github.com/MihaiBojin/jazzy-fish@main#subdirectory=python"
 ```
 
 The implementation roughly works as follows:
@@ -115,7 +115,7 @@ This repository uses [uv](https://docs.astral.sh/uv/). Install it, then one comm
 development environment:
 
 ```shell
-git clone git@github.com:jazzy-fish/jazzy-fish.git
+git clone git@github.com:MihaiBojin/jazzy-fish.git
 cd jazzy-fish/python
 uv sync --all-extras
 ```

--- a/python/README.md
+++ b/python/README.md
@@ -1,12 +1,12 @@
 # Jazzy Fish - Sufficiently-large, unique, human-friendly identifiers
 
-![Build Status](https://github.com/jazzy-fish/jazzy-fish/actions/workflows/python-tests.yml/badge.svg)
+![Build Status](https://github.com/MihaiBojin/jazzy-fish/actions/workflows/python-tests.yml/badge.svg)
 [![PyPI version](https://badge.fury.io/py/jazzy-fish.svg)](https://badge.fury.io/py/jazzy-fish)
 [![Python Versions](https://img.shields.io/pypi/pyversions/jazzy-fish.svg)](https://pypi.org/project/jazzy-fish/)
-[![License](https://img.shields.io/github/license/jazzy-fish/jazzy-fish.svg)](LICENSE)
+[![License](https://img.shields.io/github/license/MihaiBojin/jazzy-fish.svg)](LICENSE)
 
 > ⚠️ **Warning:** This library is **in development** and not yet ready for production. Its API is not yet stable
-> and might (and probably _will_) still change. Follow repository [issues](https://github.com/jazzy-fish/jazzy-fish/issues) for more information.
+> and might (and probably _will_) still change. Follow repository [issues](https://github.com/MihaiBojin/jazzy-fish/issues) for more information.
 
 Jazzy Fish is a library that helps you generate a sufficient number of identifiers, with a human-friendly kick.
 
@@ -43,7 +43,7 @@ Install it via:
 pip install jazzy-fish
 
 # or alternatively, directly from git
-pip install "git+https://github.com/jazzy-fish/jazzy-fish@main#subdirectory=python"
+pip install "git+https://github.com/MihaiBojin/jazzy-fish@main#subdirectory=python"
 ```
 
 The implementation roughly works as follows:
@@ -131,7 +131,7 @@ git tag v0.1.x
 git push origin v0.1.x
 ```
 
-A [GitHub Action](https://github.com/jazzy-fish/jazzy-fish/actions) will run, build the library and publish it to the PyPI repositories.
+A [GitHub Action](https://github.com/MihaiBojin/jazzy-fish/actions) will run, build the library and publish it to the PyPI repositories.
 
 #### Manual
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -48,9 +48,9 @@ dev = [
 ]
 
 [project.urls]
-"Bug reports" = "https://github.com/jazzy-fish/jazzy-fish/issues/new"
-"Documentation" = "https://github.com/jazzy-fish/jazzy-fish/blob/main/python/README.md"
-"Source" = "https://github.com/jazzy-fish/jazzy-fish"
+"Bug reports" = "https://github.com/MihaiBojin/jazzy-fish/issues/new"
+"Documentation" = "https://github.com/MihaiBojin/jazzy-fish/blob/main/python/README.md"
+"Source" = "https://github.com/MihaiBojin/jazzy-fish"
 
 [project.scripts]
 clean-dictionary = "jazzy_fish_tools.clean_dictionary:main"


### PR DESCRIPTION
The repo was transferred out of the `jazzy-fish` organization to `MihaiBojin`, but the metadata and docs still named the old path. 12 references across 3 files.

GitHub redirects `jazzy-fish/jazzy-fish` → `MihaiBojin/jazzy-fish`, so nothing was visibly broken — which is why this went unnoticed. The `jazzy-fish` org still exists; only the repo moved.

## Where the redirect does not save us

- **PyPI metadata.** `[project.urls]` ships inside the package, so **Source** and **Bug reports** on the [PyPI page](https://pypi.org/project/jazzy-fish/) resolve through a redirect rather than pointing at the repo.
- **OIDC trusted publishing.** The publisher matches on the repository that *runs* the workflow — `MihaiBojin/jazzy-fish`. Anyone following these URLs to configure it (as #80 requires) would enter an owner that can never match the OIDC claim.

## Changes

| File | Refs |
|---|---|
| `README.md` | 4 — build badge, license badge, pip install, git clone |
| `python/README.md` | 5 — build badge, license badge, issues, pip install, Actions |
| `python/pyproject.toml` | 3 — `Bug reports`, `Documentation`, `Source` |

## Verification

Every distinct rewritten URL returns **200 without a redirect**, including both badge images and the SSH clone URL (`git ls-remote` succeeds). `make lint` passes.

Note the published 0.3.0 and 0.3.1 metadata keeps the old URLs — they still work via redirect, and the corrected values ship with the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)