### PR TITLE
Widen the publish verification retry budget

### DIFF
--- a/python/scripts/verify-publish.bash
+++ b/python/scripts/verify-publish.bash
@@ -14,10 +14,17 @@ readonly VERSION
 PROJECT_NAME="$(get_project_name)"
 readonly PROJECT_NAME
 
+# Retries a command, backing off exponentially.
+#
+# This exists for one reason: a freshly uploaded release takes time to appear
+# on the index it was just accepted by. The previous budget of three retries
+# 5s apart gave up after ~30s of waiting and failed a release that had in fact
+# published correctly, so the delays now grow to cover several minutes.
 retry() {
-    MAX_ATTEMPTS=4
+    # One attempt plus five retries: 15s, 30s, 60s, 120s, 240s (~7.75 min).
+    MAX_ATTEMPTS=6
     count=0
-    base=5
+    base=15
     local command="$*"
     while [ "$count" -lt "$MAX_ATTEMPTS" ]; do
         count=$((count + 1))
@@ -31,8 +38,8 @@ retry() {
         fi
 
         echo
-        echo "Retring ($count/$((MAX_ATTEMPTS - 1)))..."
-        delay=$((base * count))
+        echo "Retrying ($count/$((MAX_ATTEMPTS - 1)))..."
+        delay=$((base * 2 ** (count - 1)))
         echo "Sleeping for $delay seconds before retrying..."
         sleep "$delay"
     done


### PR DESCRIPTION
The **v0.3.3 release failed at `Verify package install from PyPI` on a release that had published correctly.**

Both uploads succeeded, but PyPI's index had not propagated within the retry budget — a 30s wait, then three retries 5s/10s/15s apart, giving up after roughly a minute:

```
Because there is no version of jazzy-fish[cli]==0.3.3 ...
Retring (3/3)... Sleeping for 15 seconds before retrying...
Failed after 4 attempts
```

0.3.3 was live the whole time. Installing it manually a few minutes later worked, `verify_install.py` returned `OK.`, and `/pypi/jazzy-fish/0.3.3/json` returned 200 on both indexes. The result was a red workflow run against a good release — confusing, and it would recur.

## Change

Five retries, backing off exponentially:

| retry | sleep |
|---|---|
| 1/5 | 15s |
| 2/5 | 30s |
| 3/5 | 60s |
| 4/5 | 120s |
| 5/5 | 240s |

**~7m45s of waiting instead of 30s.** The delays only apply when a check fails, so a release that propagates promptly is completely unaffected — the first attempt still succeeds immediately.

Also fixes the `Retring` typo.

## Verification

Exercised the loop with a command failing twice then succeeding: retries are announced `1/5`, `2/5`, and it exits 0 on the third attempt. Schedule confirmed as 15/30/60/120/240 totalling 465s. `make lint` passes.

## Note

This treats the symptom, not the cause — PyPI propagation is outside our control, and a longer budget is the standard remedy. If a release ever genuinely fails to publish, this now takes ~8 minutes to report it rather than ~1. That trade seems right: a false failure on a good release is worse than a slow report of a real one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)