### PR TITLE
Release 0.4.0

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -14,7 +14,7 @@ readme = { "file" = "README.md", "content-type" = "text/markdown" }
 authors = [
     { name = "Mihai Bojin", email = "557584+MihaiBojin@users.noreply.github.com" },
 ]
-version = "0.3.3"
+version = "0.4.0"
 dependencies = []
 requires-python = ">=3.12"
 classifiers = [

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -139,7 +139,7 @@ wheels = [
 
 [[package]]
 name = "jazzy-fish"
-version = "0.3.3"
+version = "0.4.0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
Bumps `version` to `0.4.0` so the next tag can publish. `0.3.3` is already on PyPI, and `check-tag-version.bash` now rejects any tag that disagrees with `pyproject.toml`.

## Why 0.4.0 and not 0.3.4

#79 raised the floor to **Python 3.12**, dropping 3.11 — which this package has advertised since v0.3.0. That's a compatibility break for users, not a patch.

The practical effect of the minor bump: pip on Python 3.11 resolves to `0.3.3` and keeps working, rather than silently picking up a release that no longer supports it. A patch bump would suggest 3.11 users could take it safely.

Say the word if you'd rather it were `0.3.4` — nothing is published until the tag is pushed.

## Changes

- `version = "0.4.0"` in `pyproject.toml`
- `uv.lock` regenerated — it records the project version now that it's static, and CI's `uv sync --locked` fails without it

## Verification

`uv sync --all-extras --locked` clean, `uv build` produces `jazzy_fish-0.4.0` artifacts, 18/18 tests and 12/12 hooks pass. `0.4.0` is unclaimed on both PyPI and test.PyPI.

## After merging

`git tag v0.4.0 && git push origin v0.4.0`. This release exercises two things for the first time: the widened retry budget from #83 (7m45s of PyPI propagation tolerance instead of 30s, which is what made v0.3.3 look like a failure), and publishing a 3.12-only package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)