### PR TITLE
Tag and publish releases from a merged version bump

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -5,6 +5,10 @@ on:
   push:
     tags:
       - "v0.*"
+  # How tag-release.yml starts this workflow: a tag it pushes with GITHUB_TOKEN
+  # does not raise a push event, but workflow_dispatch is exempt from that rule.
+  # Run it against a tag ref, not a branch.
+  workflow_dispatch:
 
 jobs:
   lint-test:
@@ -49,6 +53,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
+        with:
+          # check-tag-version.bash reads the tags at HEAD, which a default
+          # checkout does not fetch when dispatched rather than pushed.
+          fetch-tags: true
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v9.0.0

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,0 +1,57 @@
+name: Tag Release
+
+on:
+  # Every push to main, but only a version bump results in a tag
+  push:
+    branches:
+      - main
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    permissions:
+      # Push the tag
+      contents: write
+      # Dispatch the publish workflow
+      actions: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v9.0.0
+        with:
+          python-version: "3.14"
+          enable-cache: true
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Tag the release
+        id: tag
+        working-directory: python
+        run: echo "tag=$(scripts/tag-release.bash)" >>"$GITHUB_OUTPUT"
+
+      # A tag pushed with GITHUB_TOKEN does not trigger `on: push: tags` --
+      # GitHub suppresses those events to prevent workflows recursing. Of the
+      # events that are exempt, workflow_dispatch is the one that fits, so the
+      # publish workflow is started explicitly against the new tag. This avoids
+      # keeping a long-lived PAT solely to make a tag push observable.
+      - name: Publish the tagged release
+        if: steps.tag.outputs.tag != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          echo "Dispatching python-publish.yml against ${{ steps.tag.outputs.tag }}..."
+          gh workflow run python-publish.yml --ref "${{ steps.tag.outputs.tag }}"
+
+      - name: Report
+        run: |
+          if [ -n "${{ steps.tag.outputs.tag }}" ]; then
+            echo "Released ${{ steps.tag.outputs.tag }}" >>"$GITHUB_STEP_SUMMARY"
+          else
+            echo "No version change; nothing to release." >>"$GITHUB_STEP_SUMMARY"
+          fi

--- a/python/README.md
+++ b/python/README.md
@@ -123,24 +123,29 @@ Unless you are interested in contributing to this code (or are curious about thi
 
 #### GitHub-based version publishing
 
-The version lives in `version` under `[project]` in `pyproject.toml`. Bump it in a pull request, then
-tag the merged commit:
+Releasing is merging a version bump. Nothing is tagged or published by hand.
 
 ```shell
-# 1. In a PR: set the new version and refresh the lock file
-#    (uv.lock records the project version, so CI's `uv sync --locked` fails without this)
+# In a release branch: set the new version and refresh the lock file
+#   (uv.lock records the project version, so CI's `uv sync --locked` fails without this)
 uv lock
-
-# 2. After merging, tag that commit and push
-git tag v0.1.x
-git push origin v0.1.x
 ```
 
-The tag must match the version in `pyproject.toml`. The workflow runs `scripts/check-tag-version.bash`
-before building and refuses to publish on a mismatch, so a forgotten bump fails the release rather than
-publishing the previous version again.
+Open a pull request with that change. Once it merges, `tag-release.yml` reads `version` from
+`pyproject.toml` and, if no matching tag exists yet, tags the merge commit `v<version>` and starts the
+publish workflow against it.
 
-A [GitHub Action](https://github.com/MihaiBojin/jazzy-fish/actions) will run, build the library and publish it to the PyPI repositories.
+Pushes to `main` that do not change the version find their tag already present and do nothing, so the
+workflow is a no-op except on a release.
+
+A tag pushed by a workflow does not raise a `push` event -- GitHub suppresses events made with
+`GITHUB_TOKEN` so workflows cannot trigger themselves. `tag-release.yml` therefore starts
+`python-publish.yml` through `workflow_dispatch`, which is exempt from that rule, so no long-lived
+personal access token is needed. Pushing a `v0.*` tag by hand still works and takes the ordinary
+`push` path.
+
+`python-publish.yml` runs `scripts/check-tag-version.bash` before building, and refuses to publish if
+the tag and `pyproject.toml` disagree.
 
 The workflow authenticates with [Trusted Publishing](https://docs.pypi.org/trusted-publishers/), so it
 holds no API tokens. PyPI and test.PyPI each exchange the workflow's OIDC identity for a short-lived

--- a/python/scripts/tag-release.bash
+++ b/python/scripts/tag-release.bash
@@ -1,0 +1,58 @@
+#!/bin/bash
+set -ueo pipefail
+
+# Tags HEAD with the version in pyproject.toml, unless that tag already exists.
+#
+# Run on every push to main: pushes that do not change the version find their
+# tag already present and do nothing, so only a merged version bump creates a
+# release.
+#
+# Writes the created tag to stdout and nothing at all when there was nothing to
+# do, so a caller can branch on it. All commentary goes to stderr.
+#
+# Pass --dry-run to skip creating and pushing the tag.
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+readonly DIR
+
+# shellcheck disable=SC1091
+source "$DIR/functions.bash"
+
+DRY_RUN=""
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+    --dry-run)
+        DRY_RUN="yes"
+        ;;
+    *)
+        echo "Error: unsupported argument $1" >&2
+        exit 1
+        ;;
+    esac
+    shift
+done
+readonly DRY_RUN
+
+VERSION="$(get_project_version)"
+readonly VERSION
+TAG="v$VERSION"
+readonly TAG
+
+# Ask the remote rather than the local clone: a CI checkout may not have
+# fetched tags, and the remote is what decides whether the tag is taken.
+if git ls-remote --exit-code --tags origin "refs/tags/$TAG" >/dev/null 2>&1; then
+    echo "Tag $TAG already exists on origin; nothing to release." >&2
+    exit 0
+fi
+
+if [ -n "$DRY_RUN" ]; then
+    echo "[dry-run] would tag HEAD ($(git rev-parse --short HEAD)) as $TAG" >&2
+    echo "$TAG"
+    exit 0
+fi
+
+echo "Tagging HEAD ($(git rev-parse --short HEAD)) as $TAG..." >&2
+git tag -a "$TAG" -m "Release $VERSION"
+git push origin "$TAG" >&2
+
+echo "$TAG"


### PR DESCRIPTION
Releasing meant remembering to push a tag by hand after the bump merged, with nothing tying the two together. **A release is now the merge itself.**

```
release branch (bump version + uv lock)
        │  merge
        ▼
tag-release.yml ── version already tagged? ──▶ no-op
        │ no
        ▼
   tag v<version>  ──dispatch──▶  python-publish.yml ──▶ test.PyPI ▶ PyPI
```

## How it works

`tag-release.yml` runs on **every** push to `main`, reads `version` from `pyproject.toml`, and tags the commit when no such tag exists. Pushes that don't change the version find their tag already present and do nothing — so the workflow is a no-op except on a release.

Tag existence is checked against **the remote**, not the local clone: a CI checkout hasn't necessarily fetched tags, and the remote is what decides whether the name is taken.

## The awkward part, and why it's solved this way

**A tag pushed with `GITHUB_TOKEN` does not raise a `push` event.** GitHub suppresses those so workflows can't trigger themselves — [documented](https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/trigger-a-workflow) as "events triggered by the `GITHUB_TOKEN` will not create a new workflow run". Naively, the tag would be created and then sit there, never published.

The documented exception is that "`workflow_dispatch` and `repository_dispatch` events always create workflow runs". So `tag-release.yml` starts `python-publish.yml` explicitly against the new tag.

The usual alternative is a Personal Access Token whose only job is to make a tag push observable — a long-lived credential, which would undo much of the point of #80 moving publishing to OIDC.

## Changes

- **`tag-release.yml`** — new; `contents: write` to push the tag, `actions: write` to dispatch
- **`tag-release.bash`** — the logic, so it's testable outside CI. Writes the created tag to stdout and nothing when there's nothing to do; commentary goes to stderr. Supports `--dry-run`
- **`python-publish.yml`** — gains `workflow_dispatch`, and its checkout now uses `fetch-tags: true`, since dispatched runs don't get tags the way a tag push does and `check-tag-version.bash` reads the tags at HEAD
- **README** — documents the flow

Pushing a `v0.*` tag by hand still works and takes the ordinary `push` path.

## Verification

The workflow can't run until it's on `main`, so the logic was tested locally instead:

| case | stdout | behaviour |
|---|---|---|
| version already tagged (`0.3.3`) | *(empty)* | `Tag v0.3.3 already exists on origin; nothing to release.` |
| version bumped to `0.4.0` | `v0.4.0` | `[dry-run] would tag HEAD (e36b278) as v0.4.0` |
| workflow's capture step | — | `tag=v0.4.0` written to `$GITHUB_OUTPUT` |
| bad argument | — | rejected, exit 1 |

Both workflow files parse, with triggers and permissions confirmed. `make lint` passes.

## Suggested merge order

Merge **this before #84**. Then merging #84's `0.4.0` bump exercises the new flow end to end on a real release. Done the other way round, #84 would land while `main` is still on the old flow and need a manual tag.

If the tagging step misfires, nothing is published and the fallback is unchanged — push the tag by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)