### PR TITLE
Filter Renovate updates by requires-python

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,5 +4,6 @@
     "github>MihaiBojin/renovate",
     "github>MihaiBojin/renovate:group-github-actions",
     "github>MihaiBojin/renovate:pre-commit"
-  ]
+  ],
+  "constraintsFiltering": "strict"
 }


### PR DESCRIPTION
Adds `"constraintsFiltering": "strict"` to `renovate.json`.

## The problem it addresses

Renovate proposed numpy 2.5.1 (#79) while the project still required Python 3.11 — which numpy 2.5 had dropped. The result was unmergeable: no resolution existed, so **every CI job failed before running a test**, and Renovate would have kept reproposing it.

```
Because only numpy==2.5.1 is available and jazzy-fish[cli] depends on
numpy==2.5.1, we can conclude that jazzy-fish[cli]'s requirements are
unsatisfiable.
```

Renovate already reads `requires-python` from `pyproject.toml`, but **it doesn't act on it unless `constraintsFiltering` is set** — the default `none` offers every release regardless of whether the project could use it. `strict` keeps a release out of consideration when its own constraints don't match ours.

That particular case was resolved by raising the floor to 3.12, which happened to be the right answer. It won't always be — and the failure mode is identical either way: a red PR that can't be merged.

## Verification

Validated with Renovate's own tool rather than just checking it's valid JSON:

```
INFO: Validating renovate.json
INFO: Config validated successfully
```

`make lint` passes. The constraint it'll honour is `requires-python = ">=3.12"`, read automatically from `pyproject.toml` — no second place to keep in sync.

## Trade-off worth knowing

Strict filtering also excludes releases that publish **no** constraint metadata at all. So "an update went quiet" becomes a possible symptom of this setting, not only of upstream inactivity. Renovate's docs flag the same caveat. If a dependency stops receiving PRs unexpectedly, this is the first thing to check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)