### PR TITLE
Rename the workflow to cicd.yml

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -3,9 +3,10 @@
 # job dependencies rather than one workflow observing another.
 #
 # The filename is load-bearing and cannot be changed casually: PyPI and
-# test.PyPI each register a trusted publisher against 'python-publish.yml', and
-# OIDC uploads stop working the moment it disagrees.
-name: Python CI
+# test.PyPI each register a trusted publisher against 'cicd.yml', and OIDC
+# uploads stop working the moment it disagrees. Renaming means registering the
+# new name on both indexes first.
+name: CI/CD
 
 on:
   # Test pull requests; tag and publish are skipped

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Jazzy Fish - Sufficiently-large, unique, human-friendly identifiers
 
-![Build Status](https://github.com/MihaiBojin/jazzy-fish/actions/workflows/python-tests.yml/badge.svg)
+![Build Status](https://github.com/MihaiBojin/jazzy-fish/actions/workflows/cicd.yml/badge.svg)
 [![PyPI version](https://badge.fury.io/py/jazzy-fish.svg)](https://badge.fury.io/py/jazzy-fish)
 [![Python Versions](https://img.shields.io/pypi/pyversions/jazzy-fish.svg)](https://pypi.org/project/jazzy-fish/)
 [![License](https://img.shields.io/github/license/MihaiBojin/jazzy-fish.svg)](LICENSE)

--- a/python/README.md
+++ b/python/README.md
@@ -1,6 +1,6 @@
 # Jazzy Fish - Sufficiently-large, unique, human-friendly identifiers
 
-![Build Status](https://github.com/MihaiBojin/jazzy-fish/actions/workflows/python-tests.yml/badge.svg)
+![Build Status](https://github.com/MihaiBojin/jazzy-fish/actions/workflows/cicd.yml/badge.svg)
 [![PyPI version](https://badge.fury.io/py/jazzy-fish.svg)](https://badge.fury.io/py/jazzy-fish)
 [![Python Versions](https://img.shields.io/pypi/pyversions/jazzy-fish.svg)](https://pypi.org/project/jazzy-fish/)
 [![License](https://img.shields.io/github/license/MihaiBojin/jazzy-fish.svg)](LICENSE)
@@ -131,7 +131,7 @@ Releasing is merging a version bump. Nothing is tagged or published by hand.
 uv lock
 ```
 
-Open a pull request with that change. Merging it runs `python-publish.yml`, a single pipeline of three
+Open a pull request with that change. Merging it runs `cicd.yml`, a single pipeline of three
 jobs:
 
 1. **`lint-test`** -- linters and tests across every supported Python version.
@@ -153,12 +153,12 @@ long-lived personal access token or a `workflow_dispatch` hop. Job dependencies 
 ordering with none of that.
 
 Note the filename is load-bearing: PyPI and test.PyPI each register a trusted publisher against
-`python-publish.yml`, and OIDC uploads stop working the moment it disagrees.
+`cicd.yml`, and OIDC uploads stop working the moment it disagrees.
 
 The workflow authenticates with [Trusted Publishing](https://docs.pypi.org/trusted-publishers/), so it
 holds no API tokens. PyPI and test.PyPI each exchange the workflow's OIDC identity for a short-lived
 upload token, which requires `id-token: write` on the publishing job and a trusted publisher registered
-on **both** indexes, pointing at `python-publish.yml` in this repository.
+on **both** indexes, pointing at `cicd.yml` in this repository.
 
 #### Manual
 


### PR DESCRIPTION
`python-publish.yml` described a third of what the file does since #86 — it also runs the tests and tags releases. Renamed to `cicd.yml`, with `name: CI/CD`.

## ⚠️ Do not merge before updating PyPI

**PyPI and test.PyPI each register a trusted publisher against a workflow *filename*.** Once this merges, `python-publish.yml` no longer exists and OIDC uploads fail — the next release would die at the publish step.

Register a publisher for the new filename on **both** indexes *before* merging:

| Field | Value |
|---|---|
| Owner | `MihaiBojin` |
| Repository | `jazzy-fish` |
| Workflow | `cicd.yml` |
| Environment | *(leave blank)* |

- [pypi.org](https://pypi.org/manage/project/jazzy-fish/settings/publishing/)
- [test.pypi.org](https://test.pypi.org/manage/project/jazzy-fish/settings/publishing/)

PyPI allows several publishers per project, so adding `cicd.yml` alongside `python-publish.yml` is safe and leaves no window where publishing is broken. Remove the old entries once this has merged.

## Also fixes a live breakage

The build badges in both READMEs pointed at `python-tests.yml`, which #86 deleted. **They have been 404ing on `main` since that merged** — confirmed against GitHub, where `python-tests.yml/badge.svg` returns 404 while the surviving workflow returns 200. Both now point at `cicd.yml`.

## Verification

Git records it as a pure rename (`{python-publish.yml => cicd.yml} | 0`), so the pipeline content is untouched. Re-parsed after renaming to confirm the wiring survived: `lint-test` → `tag` (`contents: write`) → `publish` (`id-token: write`), triggers unchanged.

No references to the old filenames remain anywhere in the repo. `make lint` passes.

The new badge URL 404s until this is on the default branch, which is expected — GitHub resolves badges against the default branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)