### PR TITLE
Release 0.4.1

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -14,7 +14,7 @@ readme = { "file" = "README.md", "content-type" = "text/markdown" }
 authors = [
     { name = "Mihai Bojin", email = "557584+MihaiBojin@users.noreply.github.com" },
 ]
-version = "0.4.0"
+version = "0.4.1"
 dependencies = []
 requires-python = ">=3.12"
 classifiers = [

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -139,7 +139,7 @@ wheels = [
 
 [[package]]
 name = "jazzy-fish"
-version = "0.4.0"
+version = "0.4.1"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
Bumps `version` to `0.4.1`.

## What actually changes

**Nothing in the library.** The only packaged file that changed since v0.4.0 is `python/README.md`:

```
python/README.md | 36 ++++++++++++++++++++++--------------
```

It's embedded as the package description, so this ships the corrected build badge and the rewritten publishing docs to the [PyPI project page](https://pypi.org/project/jazzy-fish/) — where the badge currently points at the deleted `python-tests.yml` and renders broken. Confirmed in the built wheel's metadata:

```
![Build Status](https://github.com/MihaiBojin/jazzy-fish/actions/workflows/cicd.yml/badge.svg)
```

The other three commits since v0.4.0 (#86, #87, #88) are all CI and tooling, none of which reaches the distribution.

## Verification

`uv sync --all-extras --locked` clean, `uv build` produces `jazzy_fish-0.4.1`, 18/18 tests and 12/12 hooks pass. `0.4.1` is unclaimed on both PyPI and test.PyPI.

## What merging does

This is the **first release through the consolidated pipeline**. Merging runs `lint-test` → `tag` (finds `0.4.1` untagged, tags the commit) → `publish`. No manual tagging.

The no-op half already proved itself on the #88 merge: `tag` succeeded after the tests and `publish` skipped, since `v0.4.0` was already tagged.

## ⚠️ Prerequisite

The publish job will fail unless a trusted publisher for **`cicd.yml`** is registered on **both** [pypi.org](https://pypi.org/manage/project/jazzy-fish/settings/publishing/) and [test.pypi.org](https://test.pypi.org/manage/project/jazzy-fish/settings/publishing/) — the rename in #88 invalidated the `python-publish.yml` entries.

If it does fail, nothing is uploaded: test.PyPI is attempted first, so it stops before touching PyPI. The tag would exist for an unpublished version, and re-running the failed job after fixing the config completes the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)