### PR TITLE
Create a GitHub release for each tag

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -143,3 +143,32 @@ jobs:
       - name: Verify package install from PyPI
         working-directory: python
         run: scripts/verify-publish.bash --prod
+
+  # Publishing to PyPI leaves the GitHub side of a release bare: a tag and
+  # nothing else. This turns each tag into a release whose notes are built from
+  # the pull requests merged since the previous one, so what changed between two
+  # versions is visible without reading the commit log.
+  #
+  # A separate job to keep 'publish' scoped to 'contents: read'; writing a
+  # release needs 'contents: write'.
+  github-release:
+    needs: [tag, publish]
+    # Redundant with the skipped 'publish' it depends on, but stated so the
+    # condition for running is readable in one place
+    if: needs.tag.outputs.tag != ''
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      # No checkout: gh talks to the API, and GH_REPO tells it which repository.
+      - name: Create the GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ needs.tag.outputs.tag }}
+        # --verify-tag refuses to invent a tag that is not on the remote, so a
+        # half-finished release cannot leave a release pointing at nothing.
+        run: |
+          gh release create "$TAG" --generate-notes --verify-tag
+          echo "Created release $TAG" >>"$GITHUB_STEP_SUMMARY"

--- a/python/README.md
+++ b/python/README.md
@@ -131,7 +131,7 @@ Releasing is merging a version bump. Nothing is tagged or published by hand.
 uv lock
 ```
 
-Open a pull request with that change. Merging it runs `cicd.yml`, a single pipeline of three
+Open a pull request with that change. Merging it runs `cicd.yml`, a single pipeline of four
 jobs:
 
 1. **`lint-test`** -- linters and tests across every supported Python version.
@@ -139,6 +139,9 @@ jobs:
    already exists. It needs `lint-test`, so nothing is tagged until the tests pass: a bad tag is far
    more awkward to retract than a failed build is to fix.
 3. **`publish`** -- builds the tag and uploads it to test.PyPI and PyPI.
+4. **`github-release`** -- turns the tag into a [release](https://github.com/MihaiBojin/jazzy-fish/releases),
+   with notes generated from the pull requests merged since the previous one. The notes are only as
+   informative as the pull request titles they are built from.
 
 Merges that do not change the version find their tag already present, and `publish` is skipped. Pull
 requests run `lint-test` only.


### PR DESCRIPTION
**Step 1 and step 2 of the plan.** Publishing to PyPI left the GitHub side of a release bare — a tag and nothing else. Sixteen tags, zero releases, no changelog.

That mattered most for the two most recent versions: nothing recorded that **0.4.0 dropped Python 3.11** (a compatibility break) or that **0.4.1 changed no code**. A user saw only a version number.

## Step 1 — the new job

```yaml
github-release:
  needs: [tag, publish]
  if: needs.tag.outputs.tag != ''
  permissions:
    contents: write
  steps:
    - run: gh release create "$TAG" --generate-notes --verify-tag
```

- **A separate job** so `publish` keeps `contents: read` — writing a release needs `contents: write`
- **No checkout**: `gh` talks to the API, and `GH_REPO` tells it which repository
- **`--verify-tag`** refuses to invent a tag that isn't on the remote, so a half-finished run can't leave a release pointing at nothing
- Notes come from merged pull request titles, so this needs **no commit-message convention**

## Step 2 — backfill (already applied)

All 16 existing tags now have releases, each created with `--notes-start-tag` set to its predecessor so the boundaries are right rather than every release claiming the whole history. Verified: **16 releases for 16 tags**, `v0.4.1` marked `Latest`, and the compare links are correctly scoped —

```
v0.4.0 → **Full Changelog**: .../compare/v0.3.3...v0.4.0
```

This is done and live; it needed no code change, so it isn't part of this diff.

## Honest limitation

Generated notes are only as informative as the pull request titles behind them. `v0.4.0`'s notes list *"Update dependency numpy to v2.5.1 (#79)"* — which **is** the Python 3.11 drop, but you would not know that from the title. Getting release notes that state the breaking change requires either writing them by hand or deriving them from structured commits, which is what issue #12 is about. Worth deciding separately.

## Verification

The pipeline parses with four jobs wired `lint-test → tag → publish → github-release`, permissions `contents: write` / `id-token: write` / `contents: write` respectively. `make lint` passes. Notes generation was validated on a real release before backfilling the rest.

Merging this is a no-op release-wise (no version change), so `tag`, `publish` and `github-release` all skip. The next version bump exercises the new job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)